### PR TITLE
Add support for dispatchOnComplete and dispatchOnDismiss

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,16 @@ namespace App\Filament\Pages;
   
 use JibayMcs\FilamentTour\Tour\HasTour;
   
-class Dashboard extends FilamentDashboard {
-
+class Dashboard extends FilamentDashboard 
+{
     use HasTour;
     // ...  
 
-	public function tours(): array    {    
+	public function tours(): array
+	{    
 		return []; 
-    	}
-}  
+	}
+}
 ```
 ___
 
@@ -92,11 +93,11 @@ ___
 use JibayMcs\FilamentTour\Tour\Step;
 use JibayMcs\FilamentTour\Tour\Tour;
 
-public function tours(): array {
+public function tours(): array 
+{
     return [
        Tour::make('dashboard')
-           ->steps(
-                           
+           ->steps(        
                Step::make()
                    ->title("Welcome to your Dashboard !")
                    ->description(view('tutorial.dashboard.introduction')),
@@ -157,6 +158,53 @@ public function renderPostTour(bool $only_visible_once, array $tours, array $hig
     $this->dispatch('filament-tour::open-tour', $firstTourID);
 }
 ```
+
+### Use Events for your custom business logic
+
+Sometimes you want to run business logic in when certain lifecycle event like completed and dismissed occurs. Here is how to: 
+
+```php
+use JibayMcs\FilamentTour\Tour\Step;
+use JibayMcs\FilamentTour\Tour\Tour;
+use Livewire\Attributes\On;
+
+#[On('dashboard-tour-completed')]
+public function completed($params): void
+{
+    // your logic here
+}
+
+#[On('dashboard-tour-dismissed')]
+public function dismissed($params): void
+{
+    // your logic here
+}
+
+public function tours(): array 
+{
+    return [
+       Tour::make('dashboard')
+           ->route('/dashboard')
+           ->alwaysShow(false)
+           ->dispatchOnComplete('dashboard-tour-completed', [
+                'foo' => 'bar',
+            ])
+            ->dispatchOnDismiss('dashboard-tour-dismissed', [
+                'foo' => 'bar',
+            ])
+           ->steps(        
+               Step::make()
+                   ->title("Welcome to your Dashboard !")
+                   ->description(view('tutorial.dashboard.introduction')),
+               Step::make('.fi-avatar')
+                   ->title('Woaw ! Here is your avatar !')
+                   ->description('You look nice !'),
+           ),
+    ];
+}
+```
+
+
 
 You can also bring up tours for users when they click on a button. See more in the (Event)[#events] section.
 
@@ -305,6 +353,12 @@ Tour::make(... $params)
     
     // Disable all tour steps events
     ->disableEvents(bool|Closure $disableEvents = true)
+    
+    // Dispatch an event like `$dispatch()` when the user completes the tour
+    ->dispatchOnComplete(string $name, ...$args)
+    
+    // Dispatch an event like `$dispatch()` when the user dismisses the tour
+    ->dispatchOnDismiss(string $name, ...$args)
     
     // Bypass route check to show the tour on all pages
     // Maybe useless, but who knows ?

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -99,7 +99,6 @@ document.addEventListener('livewire:initialized', async function () {
         }
     }
 
-
     Livewire.on('filament-tour::open-highlight', function (params) {
 
         const id = parseId(params);
@@ -164,9 +163,15 @@ document.addEventListener('livewire:initialized', async function () {
                     if (!localStorage.getItem('tours').includes(tour.id)) {
                         localStorage.setItem('tours', JSON.stringify([...JSON.parse(localStorage.getItem('tours')), tour.id]));
                     }
+                    if (tour.dispatchOnDismiss) {
+                        Livewire.dispatch(tour.dispatchOnDismiss.name, tour.dispatchOnDismiss.params);
+                    }
                 }),
                 onDestroyStarted: ((element, step, {config, state}) => {
                     if (state.activeStep && !state.activeStep.uncloseable && !tour.uncloseable) {
+                        if (tour.dispatchOnDismiss) {
+                            Livewire.dispatch(tour.dispatchOnDismiss.name, tour.dispatchOnDismiss.params);
+                        }
                         driverObj.destroy();
                     }
                 }),
@@ -174,8 +179,6 @@ document.addEventListener('livewire:initialized', async function () {
 
                 }),
                 onNextClick: ((element, step, {config, state}) => {
-
-
                     if (tours.length > 1 && driverObj.isLastStep()) {
                         let index = tours.findIndex(objet => objet.id === tour.id);
 
@@ -185,11 +188,13 @@ document.addEventListener('livewire:initialized', async function () {
                         }
                     }
 
-
                     if (driverObj.isLastStep()) {
-
                         if (!localStorage.getItem('tours').includes(tour.id)) {
                             localStorage.setItem('tours', JSON.stringify([...JSON.parse(localStorage.getItem('tours')), tour.id]));
+                        }
+
+                        if (tour.dispatchOnComplete) {
+                            Livewire.dispatch(tour.dispatchOnComplete.name, tour.dispatchOnComplete.params);
                         }
 
                         driverObj.destroy();

--- a/src/Tour/HasTour.php
+++ b/src/Tour/HasTour.php
@@ -68,6 +68,10 @@ trait HasTour
 
                         'uncloseable' => $tour->isUncloseable(),
 
+                        'dispatchOnComplete' => $tour->getDispatchOnComplete(),
+
+                        'dispatchOnDismiss' => $tour->getDispatchOnDismiss(),
+
                         'route' => $route,
 
                         'id' => "{$prefixId}{$tour->getId()}",

--- a/src/Tour/Tour.php
+++ b/src/Tour/Tour.php
@@ -6,11 +6,13 @@ use Closure;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Illuminate\Support\Facades\Lang;
 use JibayMcs\FilamentTour\Tour\Traits\CanReadJson;
+use JibayMcs\FilamentTour\Tour\Traits\HasTourEvent;
 
 class Tour
 {
     use CanReadJson;
     use EvaluatesClosures;
+    use HasTourEvent;
 
     private string $id;
 

--- a/src/Tour/Traits/HasTourEvent.php
+++ b/src/Tour/Traits/HasTourEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace JibayMcs\FilamentTour\Tour\Traits;
+
+trait HasTourEvent
+{
+    private ?array $dispatchOnComplete = null;
+    private ?array $dispatchOnDismiss = null;
+
+    public function dispatchOnComplete(string $name, ...$params): self
+    {
+        $this->dispatchOnComplete = ['name' => $name, 'params' => $params];
+
+        return $this;
+    }
+
+    public function getDispatchOnComplete(): ?array
+    {
+        return $this->dispatchOnComplete;
+    }
+
+    public function dispatchOnDismiss(string $name, ...$params): self
+    {
+        $this->dispatchOnDismiss = ['name' => $name, 'params' => $params];
+
+        return $this;
+    }
+
+    public function getDispatchOnDismiss(): ?array
+    {
+        return $this->dispatchOnDismiss;
+    }
+
+}


### PR DESCRIPTION
This PR adds support for lifecycle events when user dismisses or completes a tour. 

Its used the following way, which is also added to readme. 

```php
use JibayMcs\FilamentTour\Tour\Step;
use JibayMcs\FilamentTour\Tour\Tour;
use Livewire\Attributes\On;

#[On('dashboard-tour-completed')]
public function completed($params): void
{
    // your logic here
}

#[On('dashboard-tour-dismissed')]
public function dismissed($params): void
{
    // your logic here
}

public function tours(): array 
{
    return [
       Tour::make('dashboard')
           ->route('/dashboard')
           ->alwaysShow(false)
           ->dispatchOnComplete('dashboard-tour-completed', [
                'foo' => 'bar',
            ])
            ->dispatchOnDismiss('dashboard-tour-dismissed', [
                'foo' => 'bar',
            ])
           ->steps(        
               Step::make()
                   ->title("Welcome to your Dashboard !")
                   ->description(view('tutorial.dashboard.introduction')),
               Step::make('.fi-avatar')
                   ->title('Woaw ! Here is your avatar !')
                   ->description('You look nice !'),
           ),
    ];
}
``` 